### PR TITLE
feat: 멀티플레이 점수 동기화 구현

### DIFF
--- a/Assets/DefaultNetworkPrefabs.asset
+++ b/Assets/DefaultNetworkPrefabs.asset
@@ -44,3 +44,8 @@ MonoBehaviour:
     SourcePrefabToOverride: {fileID: 0}
     SourceHashToOverride: 0
     OverridingTargetPrefab: {fileID: 0}
+  - Override: 0
+    Prefab: {fileID: 7685677013673253918, guid: 98529adb58502354788ba9574113970c, type: 3}
+    SourcePrefabToOverride: {fileID: 0}
+    SourceHashToOverride: 0
+    OverridingTargetPrefab: {fileID: 0}

--- a/Assets/Prefabs/PlayerData.prefab
+++ b/Assets/Prefabs/PlayerData.prefab
@@ -1,0 +1,70 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7685677013673253918
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7227963343677231436}
+  - component: {fileID: 4607900768009844569}
+  - component: {fileID: 2753590125696136538}
+  m_Layer: 0
+  m_Name: PlayerData
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7227963343677231436
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7685677013673253918}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4607900768009844569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7685677013673253918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 931125425
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+  SyncOwnerTransformWhenParented: 1
+  AllowOwnerToParent: 0
+--- !u!114 &2753590125696136538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7685677013673253918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc796f93fbdabf84999cbf40c875cf87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/PlayerData.prefab.meta
+++ b/Assets/Prefabs/PlayerData.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 98529adb58502354788ba9574113970c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TuhoGame.unity
+++ b/Assets/Scenes/TuhoGame.unity
@@ -149,6 +149,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameManagerPrefab: {fileID: 2421703667477906408, guid: d775a00ecd3d3cc46a5fc26773f27e92, type: 3}
+  playerDataPrefab: {fileID: 7685677013673253918, guid: 98529adb58502354788ba9574113970c, type: 3}
 --- !u!4 &312494973
 Transform:
   m_ObjectHideFlags: 0
@@ -840,7 +841,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Score: 0'
+  m_text: Loading...
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -875,7 +876,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
+  m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -935,8 +936,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -200, y: -50}
-  m_SizeDelta: {x: 250, y: 50}
+  m_AnchoredPosition: {x: -200, y: -250}
+  m_SizeDelta: {x: 400, y: 400}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1720539857
 GameObject:
@@ -1052,6 +1053,7 @@ GameObject:
   - component: {fileID: 1721838137}
   - component: {fileID: 1721838136}
   - component: {fileID: 1721838135}
+  - component: {fileID: 1721838140}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1157,6 +1159,19 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &1721838140
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721838134}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 913318e92e0bba94d89739ff96a674a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scoreText: {fileID: 1622864487}
 --- !u!1 &1803933199
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AllPlayerDataManager.cs
+++ b/Assets/Scripts/AllPlayerDataManager.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Unity.Netcode;
+using UnityEngine;
+
+public class AllPlayerDataManager : NetworkBehaviour
+{
+    public static AllPlayerDataManager Instance;
+
+    private NetworkList<PlayerData> allPlayerData;
+    private const int DEFAULT_LIFE = 3;
+
+    public event Action<ulong> OnPlayerScoreChanged;
+    public event Action<ulong> OnPlayerDead;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        allPlayerData = new NetworkList<PlayerData>();
+    }
+
+    public override void OnNetworkSpawn()
+    {
+        if (IsServer)
+        {
+            AddNewClientToList(NetworkManager.LocalClientId);
+        }
+        allPlayerData.OnListChanged += HandleAllPlayerDataChanged;
+        NetworkManager.Singleton.OnClientConnectedCallback += AddNewClientToList;
+    }
+
+    private void OnDisable()
+    {
+        if (NetworkManager.Singleton != null)
+            NetworkManager.Singleton.OnClientConnectedCallback -= AddNewClientToList;
+
+        allPlayerData.OnListChanged -= HandleAllPlayerDataChanged;
+    }
+
+
+    private void HandleAllPlayerDataChanged(NetworkListEvent<PlayerData> changeEvent)
+    {
+        // 클라이언트 UI 갱신
+        OnPlayerScoreChanged?.Invoke(changeEvent.Value.clientID);
+    }
+
+    private void AddNewClientToList(ulong clientID)
+    {
+        if (!IsServer) return;
+
+        for (int i = 0; i < allPlayerData.Count; i++)
+        {
+            if (allPlayerData[i].clientID == clientID) return;
+        }
+
+        PlayerData newPlayer = new PlayerData(clientID, 0, DEFAULT_LIFE);
+        allPlayerData.Add(newPlayer);
+        PrintAllPlayerPlayerList();
+    }
+
+    private void PrintAllPlayerPlayerList()
+    {
+        foreach (var playerData in allPlayerData)
+        {
+            Debug.Log($"Player ID: {playerData.clientID}, Called by: {NetworkManager.Singleton.LocalClientId}");
+        }
+    }
+
+    // ---------------------------
+    // 🔥 추가된 부분 (ScoreDetector에서 호출)
+    // ---------------------------
+    [ServerRpc(RequireOwnership = false)]
+    public void AddScoreServerRpc(ulong clientId, int amount)
+    {
+        IncreaseScore(clientId, amount);
+    }
+
+    public void IncreaseScore(ulong clientId, int amount)
+    {
+        if (!IsServer) return;
+
+        for (int i = 0; i < allPlayerData.Count; i++)
+        {
+            if (allPlayerData[i].clientID == clientId)
+            {
+                PlayerData newData = new PlayerData(
+                    allPlayerData[i].clientID,
+                    allPlayerData[i].score + amount,
+                    allPlayerData[i].lifePoints
+                );
+
+                allPlayerData[i] = newData;
+                OnPlayerScoreChanged?.Invoke(clientId);
+                break;
+            }
+        }
+    }
+
+    public Dictionary<ulong, int> GetAllScores()
+    {
+        Dictionary<ulong, int> result = new Dictionary<ulong, int>();
+        for (int i = 0; i < allPlayerData.Count; i++)
+        {
+            result.Add(allPlayerData[i].clientID, allPlayerData[i].score);
+        }
+        return result;
+    }
+}

--- a/Assets/Scripts/AllPlayerDataManager.cs.meta
+++ b/Assets/Scripts/AllPlayerDataManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc796f93fbdabf84999cbf40c875cf87

--- a/Assets/Scripts/ArrowState.cs
+++ b/Assets/Scripts/ArrowState.cs
@@ -1,6 +1,10 @@
-﻿using UnityEngine;
+using Unity.Netcode;
+using UnityEngine;
 
-public class ArrowState : MonoBehaviour
+public class ArrowState : NetworkBehaviour
 {
-    public bool hasScored = false;
+    // 누가 던졌는지 식별하기 위한 ID (기본값 설정)
+    public NetworkVariable<ulong> ownerClientId = new NetworkVariable<ulong>();
+
+    public bool hasScored = false; // 로컬에서 단순 체크용으로 유지하거나 제거 가능
 }

--- a/Assets/Scripts/GameBootstrap.cs
+++ b/Assets/Scripts/GameBootstrap.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 public class GameBootstrap : MonoBehaviour
 {
     [Header("Spawn Settings")]
-    public GameObject gameManagerPrefab; // 여기에 GameManager 프리팹을 연결
+    public GameObject gameManagerPrefab;
+    public GameObject playerDataPrefab; // 🔥 새로 추가: PlayerData 프리팹 연결용 변수
 
     void Start()
     {
-        // NetworkManager의 이벤트에 구독합니다.
         if (NetworkManager.Singleton != null)
         {
             NetworkManager.Singleton.OnServerStarted += OnServerStarted;
@@ -17,23 +17,26 @@ public class GameBootstrap : MonoBehaviour
 
     private void OnServerStarted()
     {
-        // 이 코드는 오직 서버(호스트)에서만 실행됩니다.
-        // 서버가 시작되면 GameManager를 생성하고 네트워크에 스폰합니다.
         if (NetworkManager.Singleton.IsServer)
         {
-            // 중복 방지: 이미 있는지 확인
+            // 1. GameManager 생성
             if (GameManager.Instance == null)
             {
                 GameObject go = Instantiate(gameManagerPrefab);
-                // 네트워크 객체로 스폰하여 모든 클라이언트에게 복제
                 go.GetComponent<NetworkObject>().Spawn();
+            }
+
+            // 2. AllPlayerDataManager 생성 (추가된 부분)
+            if (AllPlayerDataManager.Instance == null)
+            {
+                GameObject pd = Instantiate(playerDataPrefab);
+                pd.GetComponent<NetworkObject>().Spawn();
             }
         }
     }
 
     void OnDestroy()
     {
-        // 오브젝트가 파괴될 때 이벤트 구독을 해제합니다.
         if (NetworkManager.Singleton != null)
         {
             NetworkManager.Singleton.OnServerStarted -= OnServerStarted;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,5 +1,6 @@
 // GameManager.cs
 using Unity.Netcode;
+using UnityEditor.PackageManager;
 using UnityEngine;
 
 public class GameManager : NetworkBehaviour
@@ -55,12 +56,22 @@ public class GameManager : NetworkBehaviour
     }
 
     // 이 함수도 오직 서버(호스트)에서만 호출되어야 합니다.
-    public void SpawnArrow(Vector3 position, Quaternion rotation, Vector3 force)
+    // 매개변수에 clientId 추가
+    public void SpawnArrow(ulong clientId, Vector3 position, Quaternion rotation, Vector3 force)
     {
         if (!IsServer) return;
 
         GameObject arrow = Instantiate(tuhoArrowPrefab, position, rotation);
-        arrow.GetComponent<NetworkObject>().Spawn(true);
+        NetworkObject netObj = arrow.GetComponent<NetworkObject>();
+        netObj.Spawn(true);
+
+        // 화살 주인 ID 설정
+        ArrowState state = arrow.GetComponent<ArrowState>();
+        if (state != null)
+        {
+            state.ownerClientId.Value = clientId;
+        }
+
         arrow.GetComponent<Rigidbody>().AddForce(force, ForceMode.Impulse);
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -176,9 +176,12 @@ public class PlayerController : NetworkBehaviour
 
     // 클라이언트가 서버에게 화살 던지기를 요청하는 함수
     [ServerRpc]
-    private void RequestArrowThrowServerRpc(Vector3 position, Quaternion rotation, Vector3 force)
+    private void RequestArrowThrowServerRpc(Vector3 position, Quaternion rotation, Vector3 force, ServerRpcParams rpcParams = default)
     {
-        // 이 코드도 서버(호스트)에서만 실행됩니다.
-        GameManager.Instance.SpawnArrow(position, rotation, force);
+        // rpcParams.Receive.SenderClientId를 통해 누가 요청했는지 서버는 정확히 알 수 있습니다.
+        ulong shooterId = rpcParams.Receive.SenderClientId;
+
+        // GameManager에게 쏜 사람(shooterId) 정보를 함께 전달합니다.
+        GameManager.Instance.SpawnArrow(shooterId, position, rotation, force);
     }
 }

--- a/Assets/Scripts/PlayerData.cs
+++ b/Assets/Scripts/PlayerData.cs
@@ -1,0 +1,28 @@
+using System;
+using Unity.Netcode;
+
+public struct PlayerData : IEquatable<PlayerData>, INetworkSerializable
+{
+    public ulong clientID;
+    public int score;
+    public float lifePoints;
+
+    public PlayerData(ulong clientID, int score, float lifePoints)
+    {
+        this.clientID = clientID;
+        this.score = score;
+        this.lifePoints = lifePoints;
+    }
+
+    public bool Equals(PlayerData other)
+    {
+        return clientID == other.clientID && score == other.score && lifePoints == other.lifePoints;
+    }
+
+    public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+    {
+        serializer.SerializeValue(ref clientID);
+        serializer.SerializeValue(ref score);
+        serializer.SerializeValue(ref lifePoints);
+    }
+}

--- a/Assets/Scripts/PlayerData.cs.meta
+++ b/Assets/Scripts/PlayerData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 649bc3307a7402b4c91f9b102bc9e9e2

--- a/Assets/Scripts/ScoreDetector.cs
+++ b/Assets/Scripts/ScoreDetector.cs
@@ -1,32 +1,33 @@
 using UnityEngine;
+using Unity.Netcode;
 
-public class ScoreDetector : MonoBehaviour
+public class ScoreDetector : NetworkBehaviour
 {
-    private UIManager uiManager;
-    private int score = 0;
-
-    // 게임이 시작될 때 UIManager를 한 번만 찾아둡니다.
-    void Start()
-    {
-        uiManager = FindAnyObjectByType<UIManager>();
-    }
-
     private void OnTriggerEnter(Collider other)
     {
-        if (other.CompareTag("Arrow"))
-        {
-            ArrowState arrow = other.GetComponent<ArrowState>();
-            if (arrow != null && !arrow.hasScored)
-            {
-                arrow.hasScored = true;
+        // 1. 충돌 판정은 반드시 서버에서만 수행 (중요!)
+        if (!IsServer) return;
 
-                // 점수를 올리고 UI 업데이트를 요청합니다.
-                score++;
-                if (uiManager != null)
-                {
-                    uiManager.UpdateScore(score);
-                    uiManager.ShowSuccessMessage();
-                }
+        // 2. 화살인지 확인
+        // (ArrowPhysicsController나 ArrowState가 붙어있는지 확인)
+        ArrowState arrow = other.GetComponent<ArrowState>();
+
+        if (arrow != null)
+        {
+            // 3. 이미 점수가 계산된 화살인지 확인
+            if (arrow.hasScored) return;
+
+            arrow.hasScored = true;
+
+            // 4. 화살의 주인 ID를 가져옴
+            ulong ownerId = arrow.ownerClientId.Value;
+
+            // 5. 점수 매니저에게 점수 추가 요청
+            if (AllPlayerDataManager.Instance != null)
+            {
+                // 팀원 코드의 IncreaseScore 사용
+                AllPlayerDataManager.Instance.IncreaseScore(ownerId, 1);
+                Debug.Log($"Player {ownerId} Scored!");
             }
         }
     }

--- a/Assets/Scripts/ScoreUIManager.cs
+++ b/Assets/Scripts/ScoreUIManager.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using TMPro;
+using System.Linq;
+using System.Collections;
+// using Unity.Netcode; // NetworkBehaviour를 안 쓰므로 없어도 되지만, NetworkManager 참조용으로 남겨둠
+using Unity.Netcode;
+
+// 1. NetworkBehaviour -> MonoBehaviour로 변경
+public class ScoreUIManager : MonoBehaviour
+{
+    [SerializeField] private TMP_Text scoreText;
+
+    // 2. OnNetworkSpawn 대신 Start 사용
+    private void Start()
+    {
+        StartCoroutine(InitScoreUI());
+    }
+
+    private IEnumerator InitScoreUI()
+    {
+        // 네트워크 매니저나 데이터 매니저가 준비될 때까지 대기
+        // (접속 전이라도 UI는 살아있으므로, 접속할 때까지 기다려야 함)
+        while (NetworkManager.Singleton == null || !NetworkManager.Singleton.IsListening || AllPlayerDataManager.Instance == null)
+        {
+            // 접속 대기 문구 표시 (선택 사항)
+            if (scoreText != null) scoreText.text = "Loading...";
+            yield return new WaitForSeconds(0.5f);
+        }
+
+        // 3. 이벤트 구독 및 초기화
+        AllPlayerDataManager.Instance.OnPlayerScoreChanged += HandleScoreChanged;
+        UpdateAllScores();
+    }
+
+    private void OnDestroy()
+    {
+        // 오브젝트 파괴 시 안전하게 구독 해제
+        if (AllPlayerDataManager.Instance != null)
+        {
+            AllPlayerDataManager.Instance.OnPlayerScoreChanged -= HandleScoreChanged;
+        }
+    }
+
+    private void HandleScoreChanged(ulong clientId)
+    {
+        UpdateAllScores();
+    }
+
+    private void UpdateAllScores()
+    {
+        if (AllPlayerDataManager.Instance == null) return;
+
+        var scores = AllPlayerDataManager.Instance.GetAllScores();
+        if (scores == null || scores.Count == 0)
+        {
+            scoreText.text = "Waiting for players...";
+            return;
+        }
+
+        // UI 표시 로직 (기존과 동일)
+        string finalString = "";
+        var sortedScores = scores.OrderBy(x => x.Key);
+
+        foreach (var item in sortedScores)
+        {
+            string myMark = (NetworkManager.Singleton != null && item.Key == NetworkManager.Singleton.LocalClientId) ? " (Me)" : "";
+            finalString += $"P{item.Key}{myMark}: {item.Value} pts\n";
+        }
+
+        scoreText.text = finalString;
+    }
+}

--- a/Assets/Scripts/ScoreUIManager.cs.meta
+++ b/Assets/Scripts/ScoreUIManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 913318e92e0bba94d89739ff96a674a7


### PR DESCRIPTION

<img width="3839" height="1526" alt="스크린샷 2025-11-24 164849" src="https://github.com/user-attachments/assets/773c1b71-fe4a-479e-9da8-e4726f28966b" />


- Host와 Client가 접속 시 Waiting for players...에서 점수판(P0, P1...)으로 전환됨.

- 화살이 투호통에 들어가면 해당 플레이어의 점수가 모든 화면에서 즉시 업데이트됨.

- feat/#1에서 화살이 사라지는 문제는 TuhoArrow의 Capsule Colider의 IsTrigger가 켜져 있었기 때문.

- 매니저 생성 로직 변경 (GameBootstrap.cs)

  - NetworkManager 실행 시 GameManager뿐만 아니라 AllPlayerDataManager도 프리팹으로 서버에서 스폰하도록 수정했습니다. (Hash 오류 해결)

- 화살 소유권 부여 (GameManager.cs, PlayerController.cs, ArrowState.cs)

  - 화살 생성(SpawnArrow) 시 senderClientId를 받아와 ArrowState.ownerClientId에 저장하도록 로직을 추가했습니다.

  - 이제 화살 자체가 "누가 던졌는지" 정보를 가지고 날아갑니다.

- 서버 권한 점수 판정 (ScoreDetector.cs)

  - OnTriggerEnter에서 IsServer 체크를 통해 서버에서만 점수 판정을 수행합니다.

  - 화살의 주인 ID를 식별하여 AllPlayerDataManager에 점수 증가를 요청합니다.

- 점수 관리 및 동기화 (AllPlayerDataManager.cs, PlayerData.cs)

  - NetworkList<PlayerData>를 사용하여 접속한 플레이어들의 점수를 관리합니다.

  - IncreaseScore 함수를 통해 특정 클라이언트의 점수를 증가시키고 전파합니다.

- UI 구현 (ScoreUIManager.cs)

  - NetworkObject 의존성을 제거하고 MonoBehaviour로 변경하여 Canvas 사라짐 현상을 해결했습니다.

  - WaitForSeconds를 이용해 매니저 초기화를 기다린 후, 점수 변경 이벤트(OnPlayerScoreChanged)를 구독하여 UI를 갱신합니다.